### PR TITLE
Extract a legacy mapping table module and SIDC format helpers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# convert-symbology
+
+Domain language for the library that converts military symbol identification
+codes (SIDC) between the letter-based format (MIL-STD-2525C / APP-6C) and the
+number-based format (MIL-STD-2525D / APP-6D).
+
+## Language
+
+**Letter SIDC**:
+A 15-character letter-based symbol identification code (MIL-STD-2525C / APP-6C).
+_Avoid_: charlie code, old code.
+
+**Number SIDC**:
+A 20-character digit-based symbol identification code (MIL-STD-2525D / APP-6D).
+_Avoid_: delta code, new code.
+
+**Legacy mapping table**:
+The precomputed table that maps a normalized letter code to its symbol set and
+numeric code. Owned by `lib/lookupTable.ts`, which is the only module that knows
+the stored tuple shape and sort order; callers see `findExact`, `findClosest`,
+and `findByNumeric` over `LegacyMappingEntry` records.
+_Avoid_: lookup array, legacydata, the JSON.
+
+**Normalized letter code**:
+The first 10 characters of a letter SIDC with the standard-identity and status
+characters replaced by `*`, used as the key into the legacy mapping table.
+
+**Match**:
+How close a conversion got: `exact`, `partial`, `closest`, or `failed`.
+_Avoid_: result quality, confidence.
+
+## Example dialogue
+
+> **Dev:** When a number SIDC has no exact row, what comes back?
+> **Expert:** `findByNumeric` walks the legacy mapping table from the full
+> numeric code down to entity-only. The full code is an `exact` match; every
+> broader fallback is a `partial` match. Nothing at all is `failed`.
+> **Dev:** And going the other way, from a letter SIDC?
+> **Expert:** Normalize it first, then `findExact` on the normalized letter
+> code. Miss, and `findClosest` shortens the function-id suffix until a prefix
+> exists — that's a `closest` match.

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -7,13 +7,14 @@ import {
   SYMBOL_MODIFIER_MAP,
 } from "./mappings";
 
-import letter2numberTable from "./legacydata.json";
 import {
+  formatLetterSidc,
+  formatNumberSidc,
   normalizeLetterCode,
   parseLetterSidc,
   parseNumberSidc,
-  replaceCharAt,
 } from "./helpers";
+import { findByNumeric, findClosest, findExact } from "./lookupTable";
 import type {
   Letter2NumberOptions,
   Letter2NumberResult,
@@ -22,81 +23,38 @@ import type {
   Number2LetterResult,
 } from "./types";
 
-// search for the symbol in the array using binary search
-function findSymbol(digits: string): string[] | undefined {
-  let beginning = 0,
-    end = letter2numberTable.length,
-    target;
-  if (!end) {
-    return;
-  }
-  while (true) {
-    target = (beginning + end) >> 1;
-    if (
-      (target === end || target === beginning) &&
-      letter2numberTable[target][0] !== digits
-    ) {
-      return;
-    }
-    if (letter2numberTable[target][0] > digits) {
-      end = target;
-    } else if (letter2numberTable[target][0] < digits) {
-      beginning = target;
-    } else {
-      return letter2numberTable[target];
-    }
-  }
-}
-
-function findClosestSymbol(digits: string): string[] | undefined {
-  const prefix = digits.slice(0, 4);
-  const functionId = digits.slice(4);
-  let partialFunctionId = functionId.split("-")[0];
-  while (partialFunctionId.length >= 1) {
-    const match = letter2numberTable.find(([letters]) =>
-      letters.startsWith(prefix + partialFunctionId),
-    );
-    if (match) return match;
-    partialFunctionId = partialFunctionId.slice(0, -1);
-  }
-  return undefined;
-}
-
 export function convertLetterSidc2NumberSidc(
   letterSidc: string,
   options: Letter2NumberOptions = {},
 ): Letter2NumberResult {
-  const { standardIdentity, status } = parseLetterSidc(
+  const { standardIdentity, status, symbolModifier } = parseLetterSidc(
     letterSidc.replaceAll("*", "-"),
   );
-  const symbolModifier = letterSidc.substring(10, 12).replaceAll("*", "-");
 
   const normalizedSidc = normalizeLetterCode(letterSidc).slice(0, 10);
   let sidc = "";
-  let success = false;
   let match: MatchType = "failed";
-  let hit = findSymbol(normalizedSidc);
+  let hit = findExact(normalizedSidc);
   if (hit) {
     match = "exact";
-    success = true;
   } else {
-    hit = findClosestSymbol(normalizedSidc);
+    hit = findClosest(normalizedSidc);
     if (hit) {
       match = "closest";
     }
   }
 
   if (hit) {
-    sidc = [
-      "10",
-      SID_MAP[standardIdentity === "-" ? "F" : standardIdentity],
-      hit[1],
-      STATUS_MAP[status === "-" ? "P" : status],
-      SYMBOL_MODIFIER_MAP[symbolModifier] || "000",
-      hit[2],
-    ].join("");
+    sidc = formatNumberSidc({
+      standardIdentity:
+        SID_MAP[standardIdentity === "-" ? "F" : standardIdentity],
+      symbolSet: hit.symbolSet,
+      status: STATUS_MAP[status === "-" ? "P" : status],
+      amplifier: SYMBOL_MODIFIER_MAP[symbolModifier] || "000",
+      numericCode: hit.numericCode,
+    });
   }
-  return { sidc, success, match };
+  return { sidc, success: match === "exact", match };
 }
 
 export function convertLetterCode2NumberCode(
@@ -120,72 +78,17 @@ export function convertNumberSidc2LetterSidc(
     parts.hqemt === "000"
       ? "--"
       : INVERTED_SYMBOL_MODIFIER_MAP[parts.hqemt] || "--";
-  const nCode = parts.mainIcon + parts.modifierOne + parts.modifierTwo;
-
-  const hit = letter2numberTable.find(
-    ([letterCode, symbolSet, numericCode]) => {
-      return symbolSet === parts.symbolSet && numericCode === nCode;
-    },
-  );
-  let sic = "";
-  let match: MatchType = "failed";
-
-  if (hit) {
-    sic = hit[0];
-    match = "exact";
-  } else {
-    const partialCode = parts.mainIcon + parts.modifierOne + "00";
-    const secondHit = letter2numberTable.find(
-      ([letterCode, symbolSet, numericCode]) => {
-        return symbolSet === parts.symbolSet && numericCode === partialCode;
-      },
-    );
-    if (secondHit) {
-      sic = secondHit[0];
-      match = "partial";
-    } else {
-      const partialCode = parts.mainIcon + "0000";
-      const thirdHit = letter2numberTable.find(
-        ([letterCode, symbolSet, numericCode]) => {
-          return symbolSet === parts.symbolSet && numericCode === partialCode;
-        },
-      );
-      if (thirdHit) {
-        sic = thirdHit[0];
-        match = "partial";
-      } else {
-        const partialCode = parts.entity + parts.entityType + "000000";
-        const fourthHit = letter2numberTable.find(
-          ([letterCode, symbolSet, numericCode]) => {
-            return symbolSet === parts.symbolSet && numericCode === partialCode;
-          },
-        );
-        if (fourthHit) {
-          sic = fourthHit[0];
-          match = "partial";
-        } else {
-          const partialCode = parts.entity + "00000000";
-          const fifthHit = letter2numberTable.find(
-            ([letterCode, symbolSet, numericCode]) => {
-              return (
-                symbolSet === parts.symbolSet && numericCode === partialCode
-              );
-            },
-          );
-          if (fifthHit) {
-            sic = fifthHit[0];
-            match = "partial";
-          }
-        }
-      }
-    }
-  }
+  const found = findByNumeric(parts);
+  const sic = found ? found.entry.letterCode : "";
+  const match: MatchType = found ? found.match : "failed";
 
   return {
-    sidc:
-      replaceCharAt(replaceCharAt(sic, 1, standardIdentity), 3, status) +
-      symbolModifier +
-      "---",
+    sidc: formatLetterSidc({
+      letterCode: sic,
+      standardIdentity,
+      status,
+      symbolModifier,
+    }),
     success: match === "exact",
     match,
   };

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -69,3 +69,72 @@ export function parseNumberSidc(sic: string) {
     mainIcon,
   };
 }
+
+/** Fields assembled into a 15-character letter SIDC by `formatLetterSidc`. */
+export interface LetterSidcFields {
+  /** The 10-character base code (coding scheme, battle dimension, function id). */
+  letterCode: string;
+  /** Standard identity character, placed at position 1. */
+  standardIdentity: string;
+  /** Status character, placed at position 3. */
+  status: string;
+  /** Symbol modifier, placed at positions 10–11. */
+  symbolModifier: string;
+}
+
+/**
+ * Inverse of `parseLetterSidc`: overlays standard identity and status onto a
+ * 10-character base code, then appends the symbol modifier and the trailing
+ * "---" placeholder to make a 15-character letter SIDC.
+ */
+export function formatLetterSidc({
+  letterCode,
+  standardIdentity,
+  status,
+  symbolModifier,
+}: LetterSidcFields): string {
+  const head = replaceCharAt(
+    replaceCharAt(letterCode, 1, standardIdentity),
+    3,
+    status,
+  );
+  return head + symbolModifier + "---";
+}
+
+/** Fields assembled into a 20-character number SIDC by `formatNumberSidc`. */
+export interface NumberSidcFields {
+  /** Version, positions 0–2. Defaults to "10". */
+  version?: string;
+  /** Context + standard identity, positions 2–4 (2 characters). */
+  standardIdentity: string;
+  /** Symbol set, positions 4–6. */
+  symbolSet: string;
+  /** Status, position 6. */
+  status: string;
+  /** HQ/task-force/echelon amplifier block, positions 7–10 (3 characters). */
+  amplifier: string;
+  /** Entity + entity type/subtype + modifiers, positions 10–20 (10 characters). */
+  numericCode: string;
+}
+
+/**
+ * Inverse of `parseNumberSidc`: concatenates the fields of a number SIDC in
+ * position order into a 20-character code.
+ */
+export function formatNumberSidc({
+  version = "10",
+  standardIdentity,
+  symbolSet,
+  status,
+  amplifier,
+  numericCode,
+}: NumberSidcFields): string {
+  return [
+    version,
+    standardIdentity,
+    symbolSet,
+    status,
+    amplifier,
+    numericCode,
+  ].join("");
+}

--- a/lib/lookupTable.ts
+++ b/lib/lookupTable.ts
@@ -1,0 +1,117 @@
+import letter2numberTable from "./legacydata.json";
+
+/**
+ * One row of the legacy mapping table: a normalized letter SIDC and the
+ * symbol-set / numeric code it maps to.
+ */
+export interface LegacyMappingEntry {
+  letterCode: string;
+  symbolSet: string;
+  numericCode: string;
+}
+
+export type NumericMatch = "exact" | "partial";
+
+export interface NumericLookupResult {
+  entry: LegacyMappingEntry;
+  match: NumericMatch;
+}
+
+/** The fields of a parsed number SIDC the numeric lookup needs. */
+export interface NumericLookupKey {
+  symbolSet: string;
+  mainIcon: string;
+  modifierOne: string;
+  modifierTwo: string;
+  entity: string;
+  entityType: string;
+}
+
+// The raw JSON stores rows as `[letterCode, symbolSet, numericCode]` tuples
+// sorted by `letterCode`. We map them to entries once here, so this `.map` is
+// the only place that knows the stored tuple shape; everything below works
+// against `LegacyMappingEntry` and preserves the sort order.
+const entries: LegacyMappingEntry[] = letter2numberTable.map(
+  ([letterCode, symbolSet, numericCode]) => ({
+    letterCode,
+    symbolSet,
+    numericCode,
+  }),
+);
+
+// Exact `(symbolSet, numericCode)` lookups, built once. Entries are iterated in
+// their sorted-by-letterCode order and the first occurrence of each key wins,
+// reproducing the previous `Array.find` semantics for ambiguous numeric codes.
+const numericIndex = new Map<string, LegacyMappingEntry>();
+for (const entry of entries) {
+  const key = entry.symbolSet + entry.numericCode;
+  if (!numericIndex.has(key)) numericIndex.set(key, entry);
+}
+
+function lookupNumeric(
+  symbolSet: string,
+  numericCode: string,
+): LegacyMappingEntry | undefined {
+  return numericIndex.get(symbolSet + numericCode);
+}
+
+/** Exact match by normalized letter code. */
+export function findExact(
+  normalizedLetterCode: string,
+): LegacyMappingEntry | undefined {
+  let lo = 0;
+  let hi = entries.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const { letterCode } = entries[mid];
+    if (letterCode === normalizedLetterCode) return entries[mid];
+    if (letterCode < normalizedLetterCode) lo = mid + 1;
+    else hi = mid - 1;
+  }
+  return undefined;
+}
+
+/**
+ * Closest match by progressively shortening the function-id suffix of a
+ * normalized letter code, returning the first prefix that exists.
+ */
+export function findClosest(
+  normalizedLetterCode: string,
+): LegacyMappingEntry | undefined {
+  const prefix = normalizedLetterCode.slice(0, 4);
+  let partialFunctionId = normalizedLetterCode.slice(4).split("-")[0];
+  while (partialFunctionId.length >= 1) {
+    const entry = entries.find((e) =>
+      e.letterCode.startsWith(prefix + partialFunctionId),
+    );
+    if (entry) return entry;
+    partialFunctionId = partialFunctionId.slice(0, -1);
+  }
+  return undefined;
+}
+
+/**
+ * Best match for a parsed number SIDC. The numeric code is probed from most to
+ * least specific — the full code (`exact`), then progressively broader codes
+ * (`partial`): icon+modifier1, icon-only, entity+entityType, entity-only. The
+ * first probe that exists wins, carrying its own match verdict.
+ */
+export function findByNumeric(
+  key: NumericLookupKey,
+): NumericLookupResult | undefined {
+  const { symbolSet, mainIcon, modifierOne, modifierTwo, entity, entityType } =
+    key;
+
+  const probes: { code: string; match: NumericMatch }[] = [
+    { code: mainIcon + modifierOne + modifierTwo, match: "exact" },
+    { code: mainIcon + modifierOne + "00", match: "partial" },
+    { code: mainIcon + "0000", match: "partial" },
+    { code: entity + entityType + "000000", match: "partial" },
+    { code: entity + "00000000", match: "partial" },
+  ];
+  for (const { code, match } of probes) {
+    const entry = lookupNumeric(symbolSet, code);
+    if (entry) return { entry, match };
+  }
+  return undefined;
+}

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseLetterSidc, parseNumberSidc } from "../lib/helpers";
+import {
+  formatLetterSidc,
+  formatNumberSidc,
+  parseLetterSidc,
+  parseNumberSidc,
+} from "../lib/helpers";
 
 describe("Parse letter SIDC", function () {
   const testSidc = "ABCDEFGHIJKLMNO";
@@ -37,5 +42,47 @@ describe("Parse numeric SIDC", function () {
   it("gets main icon", () => {
     const s = parseNumberSidc(testSidc);
     expect(s.mainIcon).toBe("667788");
+  });
+});
+
+describe("Format number SIDC", function () {
+  it("inverts parseNumberSidc", () => {
+    const sidc = "10033000001202040000";
+    const p = parseNumberSidc(sidc);
+    expect(
+      formatNumberSidc({
+        version: p.version,
+        standardIdentity: p.context + p.standardIdentity,
+        symbolSet: p.symbolSet,
+        status: p.status,
+        amplifier: p.hqemt,
+        numericCode: p.mainIcon + p.modifierOne + p.modifierTwo,
+      }),
+    ).toBe(sidc);
+  });
+
+  it("defaults the version to 10", () => {
+    const sidc = formatNumberSidc({
+      standardIdentity: "03",
+      symbolSet: "30",
+      status: "0",
+      amplifier: "000",
+      numericCode: "1202040000",
+    });
+    expect(sidc).toBe("10033000001202040000");
+    expect(sidc.length).toBe(20);
+  });
+});
+
+describe("Format letter SIDC", function () {
+  it("places fields by position", () => {
+    const sidc = formatLetterSidc({
+      letterCode: "S*S*CLFF--",
+      standardIdentity: "F",
+      status: "P",
+      symbolModifier: "--",
+    });
+    expect(sidc).toBe("SFSPCLFF-------");
+    expect(sidc.length).toBe(15);
   });
 });


### PR DESCRIPTION
Refactors the conversion internals around two seams. The public API — `convertLetterSidc2NumberSidc`, `convertNumberSidc2LetterSidc` — is unchanged, and the change is behavior-preserving.

## Legacy mapping table module (`lib/lookupTable.ts`)

All access to `legacydata.json` now lives behind one module that owns the stored tuple shape and exposes three named queries over structured `LegacyMappingEntry` records:

- `findExact` — binary search by normalized letter code
- `findClosest` — prefix scan shortening the function-id suffix
- `findByNumeric` — a ranked probe list (most-to-least specific), each rung carrying its own `exact`/`partial` verdict

This collapses the hand-rolled binary search, the prefix scan, and the five-deep nested `if/else` numeric ladder that previously lived in `convert.ts`. Numeric lookups go through a `Map` keyed by `symbolSet+numericCode`, built first-wins over the sorted table to preserve the prior `Array.find` semantics for ambiguous codes.

## SIDC format helpers (`lib/helpers.ts`)

`formatLetterSidc` and `formatNumberSidc` sit beside the parsers, so each format's field positions live in one place for both read and write. `convert.ts` no longer carries magic positions or the `substring(10,12)` re-slice that duplicated the `symbolModifier` the parser already returns. Field-to-value mapping stays in `convert.ts`; only positioning moved.

## Also

- Adds `CONTEXT.md` recording the domain language (legacy mapping table, letter/number SIDC, match types).
- Adds round-trip tests for the format helpers.

## Tests

45/46 pass. The one failure (`Aux Ship Oiler`) **predates this branch** — it expects `SFSPNR----`, whose numeric code `1301110000` no probe in the fallback ladder generates. Untouched by this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)