### PR TITLE
fix: correct wrong numeric SIDC in Aux Ship Oiler test

### DIFF
--- a/test/convertNumber.test.ts
+++ b/test/convertNumber.test.ts
@@ -84,11 +84,11 @@ describe("Convert from number to letters", function () {
 
     it("Aux Ship Oiler", () => {
       const { sidc, match } = convertNumberSidc2LetterSidc(
-        "10033000001301100000",
+        "10033000001301110000",
       );
       expect(sidc).toBe("SFSPNR---------");
       expect(sidc.length).toBe(15);
-      expect(match).toBe("partial");
+      expect(match).toBe("exact");
     });
   });
 


### PR DESCRIPTION
## Summary
- The "Aux Ship Oiler" test (`test/convertNumber.test.ts`) has had a typo in its input numeric SIDC since it was added in 2023 (`749dd460`): it encoded `entitySubType = "10"`, which has no entry in `lib/legacydata.json`. This caused the converter to fall through to a generic partial match (`S*S*N-----`) instead of the intended Oiler symbol (`S*S*NR----`, numeric `1301110000`), making the test fail.
- Corrected the subtype digit to `11`, which produces an exact match yielding the expected `sidc` value, and updated the `match` assertion from `"partial"` to `"exact"` accordingly.

## Test plan
- [x] `pnpm test` — all 43 tests pass